### PR TITLE
fix bug

### DIFF
--- a/src/functions/split/index.py
+++ b/src/functions/split/index.py
@@ -52,7 +52,7 @@ def get_fileNameExt(filename):
     return shortname, extension
 
 def getVideoDuration(input_video):
-    cmd = '{0} -i {1} -show_entries format=duration -v quiet -of csv="p=0"'.format(
+    cmd = '{0} -i "{1}" -show_entries format=duration -v quiet -of csv="p=0"'.format(
         'ffprobe', input_video)
     raw_result = subprocess.check_output(cmd, shell=True)
     result = raw_result.decode().replace("\n", "").strip()


### PR DESCRIPTION
当input_video中带有中文括号时，该命令会执行报错。需要在命令参数{1}两侧加上双引号